### PR TITLE
Add button to open Kanban side panel from popup

### DIFF
--- a/popup/popup.html
+++ b/popup/popup.html
@@ -16,12 +16,20 @@
     <div style="margin-top:.6rem">
       <label><input type="checkbox" id="attach" checked /> Attach current page</label>
     </div>
-    <button
-      id="save"
-      style="margin-top:.75rem;padding:.5rem .7rem;border-radius:.45rem;border:1px solid #1f2937;background:#111827;color:#e6e6e6;cursor:pointer"
-    >
-      Save
-    </button>
+    <div style="display:flex;flex-direction:column;gap:.5rem;margin-top:.75rem">
+      <button
+        id="save"
+        style="padding:.5rem .7rem;border-radius:.45rem;border:1px solid #1f2937;background:#111827;color:#e6e6e6;cursor:pointer"
+      >
+        Save card
+      </button>
+      <button
+        id="open-board"
+        style="padding:.5rem .7rem;border-radius:.45rem;border:1px solid #1f2937;background:transparent;color:#e6e6e6;cursor:pointer"
+      >
+        Open Kanban board
+      </button>
+    </div>
     <script type="module" src="popup.js"></script>
   </body>
 </html>

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -33,3 +33,15 @@ document.getElementById('save').addEventListener('click', async () => {
   await saveState(state);
   window.close();
 });
+
+document.getElementById('open-board').addEventListener('click', async () => {
+  const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+  if (tab?.windowId !== undefined) {
+    try {
+      await chrome.sidePanel.open({ windowId: tab.windowId });
+    } catch (error) {
+      console.warn('KanbanX: unable to open side panel', error);
+    }
+  }
+  window.close();
+});


### PR DESCRIPTION
## Summary
- add an "Open Kanban board" button to the popup UI
- wire the new button to open the extension side panel for the current window

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e50e4253d48328af88205fefd788bd