### PR TITLE
Handle missing side panel API in popup

### DIFF
--- a/popup/popup.js
+++ b/popup/popup.js
@@ -36,12 +36,14 @@ document.getElementById('save').addEventListener('click', async () => {
 
 document.getElementById('open-board').addEventListener('click', async () => {
   const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
-  if (tab?.windowId !== undefined) {
+  if (tab?.windowId !== undefined && chrome?.sidePanel?.open) {
     try {
       await chrome.sidePanel.open({ windowId: tab.windowId });
     } catch (error) {
       console.warn('KanbanX: unable to open side panel', error);
     }
+  } else {
+    console.warn('KanbanX: side panel API unavailable');
   }
   window.close();
 });


### PR DESCRIPTION
## Summary
- guard the popup "Open board" action when the side panel API is unavailable
- add a console warning to clarify why the panel was not opened

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e50f50fc648328b677d83ed4215ef3