### PR TITLE
Add fallback when side panel API unavailable

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -10,7 +10,8 @@
   "permissions": [
     "storage",
     "contextMenus",
-    "notifications"
+    "notifications",
+    "tabs"
   ],
   "side_panel": {
     "default_path": "sidepanel/index.html"

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -35,15 +35,28 @@ document.getElementById('save').addEventListener('click', async () => {
 });
 
 document.getElementById('open-board').addEventListener('click', async () => {
+  let openedSidePanel = false;
   const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+
   if (tab?.windowId !== undefined && chrome?.sidePanel?.open) {
     try {
       await chrome.sidePanel.open({ windowId: tab.windowId });
+      openedSidePanel = true;
     } catch (error) {
       console.warn('KanbanX: unable to open side panel', error);
     }
   } else {
     console.warn('KanbanX: side panel API unavailable');
   }
+
+  if (!openedSidePanel) {
+    const boardUrl = chrome.runtime.getURL('sidepanel/index.html');
+    try {
+      await chrome.tabs.create({ url: boardUrl });
+    } catch (error) {
+      console.error('KanbanX: unable to open board fallback tab', error);
+    }
+  }
+
   window.close();
 });


### PR DESCRIPTION
## Summary
- add a fallback that opens the Kanban board in a new tab when the side panel API cannot be used
- request the tabs permission so the extension can create the fallback tab

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e514d9914c8328a0f919601a2b9e3d