### PR TITLE
Fix column movement and accurate card counts

### DIFF
--- a/sidepanel/board.js
+++ b/sidepanel/board.js
@@ -216,11 +216,18 @@ function renderColumn(board, column, query, index, totalColumns) {
     .filter((card) => card.columnId === column.id && matchesQuery(card, query))
     .sort((a, b) => (a.order ?? 0) - (b.order ?? 0));
 
+  const totalCards = columnCardCount(board, column.id);
+  const visibleCount = visibleCards.length;
+  const filterActive = query.length > 0 && visibleCount !== totalCards;
   const hasLimit = typeof column.wip === 'number' && !Number.isNaN(column.wip);
-  const wipText = hasLimit ? `${visibleCards.length} / ${column.wip}` : `${visibleCards.length}`;
-  const wipAccessible = hasLimit
-    ? `Cards in column: ${visibleCards.length} of ${column.wip}`
-    : `Cards in column: ${visibleCards.length}`;
+  const wipBaseText = hasLimit ? `${totalCards} / ${column.wip}` : `${totalCards}`;
+  const wipText = filterActive ? `${wipBaseText} (${visibleCount} shown)` : wipBaseText;
+  let wipAccessible = hasLimit
+    ? `Cards in column: ${totalCards} of ${column.wip}`
+    : `Cards in column: ${totalCards}`;
+  if (filterActive) {
+    wipAccessible += `. ${visibleCount} shown with current search.`;
+  }
 
   const disableLeft = index === 0 ? 'disabled' : '';
   const disableRight = index === totalColumns - 1 ? 'disabled' : '';

--- a/sidepanel/state.js
+++ b/sidepanel/state.js
@@ -139,6 +139,7 @@ export function moveColumn(state, columnId, offset) {
     if (targetIndex < 0 || targetIndex >= board.columns.length) return;
     const [column] = board.columns.splice(currentIndex, 1);
     board.columns.splice(targetIndex, 0, column);
+    column.order = targetIndex;
     normalizeColumnOrder(board);
   });
 }


### PR DESCRIPTION
## Summary
- update column reordering to persist the new position by adjusting order metadata before normalizing
- show card counts based on actual column totals and indicate when filtering hides cards

## Testing
- node -e "import('./sidepanel/state.js').then(m=>{const state={boards:[{id:'default',name:'My Board',columns:[{id:'c1',name:'Backlog',order:0},{id:'c2',name:'Doing',order:1},{id:'c3',name:'Done',order:2}],cards:[]}],activeBoardId:'default'};const next=m.moveColumn(state,'c2',1);console.log(next.boards[0].columns.map(c=>c.id));});" --input-type=module


------
https://chatgpt.com/codex/tasks/task_e_68e5279710cc832892a905ab3de8335b