### PR TITLE
Fix drag hover cursor when moving cards between columns

### DIFF
--- a/sidepanel/board.js
+++ b/sidepanel/board.js
@@ -72,13 +72,23 @@ export function renderBoard(state, { onState, onOpenCard, announce }) {
     }
   };
 
-  root.querySelectorAll('.card-list').forEach((zone) => {
-    zone.addEventListener('dragover', (event) => {
-      event.preventDefault();
+  const allowDrop = (event, zone) => {
+    event.preventDefault();
+    if (zone instanceof HTMLElement) {
       zone.classList.add('drag-over');
-      if (event.dataTransfer) {
-        event.dataTransfer.dropEffect = 'move';
-      }
+    }
+    if (event.dataTransfer) {
+      event.dataTransfer.dropEffect = 'move';
+    }
+  };
+
+  root.querySelectorAll('.card-list').forEach((zone) => {
+    zone.addEventListener('dragenter', (event) => {
+      allowDrop(event, zone);
+    });
+
+    zone.addEventListener('dragover', (event) => {
+      allowDrop(event, zone);
     });
 
     zone.addEventListener('dragleave', (event) => {
@@ -97,15 +107,14 @@ export function renderBoard(state, { onState, onOpenCard, announce }) {
       event.dataTransfer.effectAllowed = 'move';
     });
 
+    const listZone = cardEl.closest('.card-list');
+
+    cardEl.addEventListener('dragenter', (event) => {
+      allowDrop(event, listZone);
+    });
+
     cardEl.addEventListener('dragover', (event) => {
-      event.preventDefault();
-      const zone = cardEl.closest('.card-list');
-      if (zone) {
-        zone.classList.add('drag-over');
-      }
-      if (event.dataTransfer) {
-        event.dataTransfer.dropEffect = 'move';
-      }
+      allowDrop(event, listZone);
     });
 
     cardEl.addEventListener('drop', handleDrop);


### PR DESCRIPTION
## Summary
- ensure drag targets prevent default behavior on both dragenter and dragover
- centralize hover handling so card lists show move feedback while dragging

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e52f26c2dc8328891e60416588ce30