### PR TITLE
Handle missing board arrays when dropping cards

### DIFF
--- a/sidepanel/board.js
+++ b/sidepanel/board.js
@@ -47,8 +47,11 @@ export function renderBoard(state, { onState, onOpenCard, announce }) {
     const columnId = zone.dataset.colId;
     if (!cardId || !columnId) return;
 
-    const card = board.cards.find((item) => item.id === cardId);
-    const targetColumn = board.columns.find((col) => col.id === columnId);
+    const cards = Array.isArray(board.cards) ? board.cards : [];
+    const columns = Array.isArray(board.columns) ? board.columns : [];
+
+    const card = cards.find((item) => item.id === cardId);
+    const targetColumn = columns.find((col) => col.id === columnId);
     if (!card || !targetColumn) return;
 
     const sameColumn = card.columnId === columnId;


### PR DESCRIPTION
## Summary
- guard the drop handler against boards that are missing `cards` or `columns` arrays
- ensure we always look up dragged cards and target columns from safe fallbacks before moving them

## Testing
- not run (logic change only)

------
https://chatgpt.com/codex/tasks/task_e_68e53573746c8328b12632cd9f1ab4f8