### PR TITLE
Allow card drops past WIP limit with warning

### DIFF
--- a/sidepanel/board.js
+++ b/sidepanel/board.js
@@ -56,19 +56,24 @@ export function renderBoard(state, { onState, onOpenCard, announce }) {
 
     const sameColumn = card.columnId === columnId;
     const limit = targetColumn.wip;
+    let overLimit = false;
     if (
       !sameColumn &&
       typeof limit === 'number' &&
       limit !== null &&
       columnCardCount(board, columnId, cardId) + 1 > limit
     ) {
-      if (typeof announce === 'function') {
-        announce(`Cannot move to ${targetColumn.name}. WIP limit reached.`, 'danger');
-      }
-      return;
+      overLimit = true;
     }
 
     await onState((current) => moveCard(current, cardId, columnId));
+
+    if (overLimit && typeof announce === 'function') {
+      announce(
+        `Moved to ${targetColumn.name}. WIP limit of ${limit} exceeded.`,
+        'danger'
+      );
+    }
 
     if (dataTransfer) {
       dataTransfer.dropEffect = 'move';


### PR DESCRIPTION
## Summary
- allow cards to be dropped into columns even when the WIP limit is exceeded
- surface a warning message instead of blocking the drop when a limit is passed

## Testing
- Simulated dragging a card into an over-capacity column in the sidepanel

------
https://chatgpt.com/codex/tasks/task_e_68e53aaeec5c8328a28895c62e08d66f