### PR TITLE
Open board from extension action

### DIFF
--- a/background/service-worker.js
+++ b/background/service-worker.js
@@ -80,3 +80,27 @@ chrome.contextMenus.onClicked.addListener(async (info, tab) => {
     console.info('Notification skipped', error);
   }
 });
+
+chrome.action.onClicked.addListener(async (tab) => {
+  let openedSidePanel = false;
+
+  if (tab?.windowId !== undefined && chrome?.sidePanel?.open) {
+    try {
+      await chrome.sidePanel.open({ windowId: tab.windowId });
+      openedSidePanel = true;
+    } catch (error) {
+      console.warn('KanbanX: unable to open side panel from action', error);
+    }
+  } else {
+    console.warn('KanbanX: side panel API unavailable');
+  }
+
+  if (!openedSidePanel) {
+    const boardUrl = chrome.runtime.getURL('sidepanel/index.html');
+    try {
+      await chrome.tabs.create({ url: boardUrl });
+    } catch (error) {
+      console.error('KanbanX: unable to open board fallback tab', error);
+    }
+  }
+});

--- a/manifest.json
+++ b/manifest.json
@@ -4,8 +4,7 @@
   "description": "Local-first Kanban board in a Chrome side panel. Pure HTML/CSS/JS.",
   "version": "0.1.0",
   "action": {
-    "default_popup": "popup/popup.html",
-    "default_title": "Quick add to KanbanX"
+    "default_title": "Open KanbanX board"
   },
   "permissions": [
     "storage",


### PR DESCRIPTION
## Summary
- update the extension action so it no longer opens the quick-add popup
- add a background listener that opens the Kanban board side panel or falls back to a tab

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e550118f548328956b7704f5eeb5aa