### PR TITLE
Clarify description preview in sidepanel

### DIFF
--- a/sidepanel/details.js
+++ b/sidepanel/details.js
@@ -127,8 +127,12 @@ function renderDrawer(card, board) {
     </section>
     <section class="drawer-section">
       <h3>Description</h3>
-      <textarea id="descriptionInput" placeholder="Write in Markdown">${escapeHtml(card.description ?? '')}</textarea>
-      <div class="markdown-preview" id="descriptionPreview">${renderMarkdown(card.description ?? '')}</div>
+      <p class="drawer-hint" id="descriptionHelp">Supports Markdown syntax. The live preview updates below.</p>
+      <textarea id="descriptionInput" aria-describedby="descriptionHelp descriptionPreviewLabel" placeholder="Write in Markdown">${escapeHtml(card.description ?? '')}</textarea>
+      <div class="markdown-preview">
+        <div class="markdown-preview__label" id="descriptionPreviewLabel">Markdown preview</div>
+        <div class="markdown-preview__content" id="descriptionPreview" aria-live="polite">${renderMarkdown(card.description ?? '')}</div>
+      </div>
     </section>
     <section class="drawer-section">
       <h3>Labels</h3>

--- a/sidepanel/styles.css
+++ b/sidepanel/styles.css
@@ -327,6 +327,12 @@ header button:hover {
   resize: vertical;
 }
 
+.drawer-hint {
+  margin: 0 0 0.5rem;
+  font-size: 0.85rem;
+  color: #94a3b8;
+}
+
 .drawer textarea:focus,
 .drawer input:focus,
 .drawer select:focus {
@@ -343,6 +349,18 @@ header button:hover {
   font-size: 0.95rem;
   line-height: 1.5;
   margin-top: 0.5rem;
+}
+
+.markdown-preview__label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #94a3b8;
+  margin-bottom: 0.35rem;
+}
+
+.markdown-preview__content {
+  color: inherit;
 }
 
 .markdown-preview h1,


### PR DESCRIPTION
## Summary
- add helper text that clarifies the description supports Markdown and references the live preview
- introduce a labeled preview container so the rendered Markdown area looks intentional
- style the new helper text and preview label to match the existing drawer aesthetic

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e55c351cd883288461bdb5647150d9