### PR TITLE
Validate OAuth client ID configuration

### DIFF
--- a/sidepanel/drive.js
+++ b/sidepanel/drive.js
@@ -1,6 +1,8 @@
 const DRIVE_SETTINGS_KEY = 'kanban.drive.settings.v1';
 const DRIVE_FILE_NAME = 'kanbanx-boards.json';
 
+const PLACEHOLDER_CLIENT_ID = 'YOUR_GOOGLE_CLIENT_ID.apps.googleusercontent.com';
+
 async function getStoredSettings() {
   try {
     const { [DRIVE_SETTINGS_KEY]: settings } = await chrome.storage.local.get(
@@ -37,6 +39,15 @@ function buildMultipartBody(metadata, json) {
 function ensureIdentityAvailable() {
   if (!chrome?.identity?.getAuthToken) {
     throw new Error('Google identity API unavailable. Add "identity" permission and OAuth2 details to manifest.');
+  }
+
+  const manifest = chrome?.runtime?.getManifest?.();
+  const clientId = manifest?.oauth2?.client_id?.trim();
+
+  if (!clientId || clientId === PLACEHOLDER_CLIENT_ID) {
+    throw new Error(
+      'Google OAuth client ID missing. Replace the placeholder in manifest.json (see docs/google-drive-setup.md).'
+    );
   }
 }
 


### PR DESCRIPTION
## Summary
- ensure the Google OAuth client ID is present and not the placeholder before requesting tokens
- surface a clear error that points developers to the manifest setup docs when the client ID is missing

## Testing
- not run (extension change only)


------
https://chatgpt.com/codex/tasks/task_e_68e57c207d388328aef100a6124225f6