### PR TITLE
Fix Google Drive OAuth flow for MV3

### DIFF
--- a/auth/driveAuth.js
+++ b/auth/driveAuth.js
@@ -1,0 +1,81 @@
+const PLACEHOLDER_CLIENT_ID = 'YOUR_GOOGLE_CLIENT_ID.apps.googleusercontent.com';
+
+function getManifestClientId() {
+  const manifest = chrome?.runtime?.getManifest?.();
+  return manifest?.oauth2?.client_id?.trim() ?? '';
+}
+
+export function ensureDriveOAuthConfigured() {
+  if (!chrome?.identity?.getAuthToken) {
+    throw new Error(
+      'Google identity API unavailable. Add "identity" permission and OAuth2 details to manifest.'
+    );
+  }
+
+  const clientId = getManifestClientId();
+  if (!clientId || clientId === PLACEHOLDER_CLIENT_ID) {
+    throw new Error(
+      'Google OAuth client ID missing. Replace the placeholder in manifest.json (see docs/google-drive-setup.md).'
+    );
+  }
+}
+
+export async function getDriveToken(interactive = true) {
+  ensureDriveOAuthConfigured();
+
+  return new Promise((resolve, reject) => {
+    try {
+      chrome.identity.getAuthToken({ interactive }, (token) => {
+        if (chrome.runtime.lastError || !token) {
+          if (chrome.runtime.lastError) {
+            console.error('KanbanX: Drive auth error', chrome.runtime.lastError);
+          }
+          reject(
+            new Error(
+              chrome.runtime.lastError?.message || 'Unable to authorize with Google Drive.'
+            )
+          );
+          return;
+        }
+        if (interactive) {
+          console.info('KanbanX: Drive token acquired', token);
+        }
+        resolve(token);
+      });
+    } catch (error) {
+      reject(error);
+    }
+  });
+}
+
+export async function clearCachedDriveToken(token) {
+  if (!token || !chrome?.identity?.removeCachedAuthToken) return;
+  try {
+    await new Promise((resolve) => {
+      try {
+        chrome.identity.removeCachedAuthToken({ token }, () => resolve());
+      } catch (error) {
+        resolve();
+      }
+    });
+  } catch (error) {
+    console.warn('KanbanX: unable to remove cached Drive token', error);
+  }
+}
+
+export async function clearAllDriveTokens() {
+  if (!chrome?.identity?.clearAllCachedAuthTokens) return;
+  try {
+    await new Promise((resolve) => {
+      try {
+        chrome.identity.clearAllCachedAuthTokens(() => resolve());
+      } catch (error) {
+        resolve();
+      }
+    });
+  } catch (error) {
+    console.warn('KanbanX: unable to clear all Drive tokens', error);
+  }
+}
+
+export { PLACEHOLDER_CLIENT_ID };

--- a/background/service-worker.js
+++ b/background/service-worker.js
@@ -7,6 +7,8 @@ import {
   columnCardCount
 } from '../sidepanel/state.js';
 
+console.log('EXT_ID', chrome.runtime.id);
+
 chrome.runtime.onInstalled.addListener(async () => {
   try {
     await chrome.contextMenus.removeAll();

--- a/docs/google-drive-setup.md
+++ b/docs/google-drive-setup.md
@@ -26,28 +26,39 @@ Use one of the organisation's shared "Standard Google Users" so the client ID is
 1. Go to **APIs & Services → Enabled APIs & services**.
 2. Click **+ Enable APIs and Services**, search for **Google Drive API**, and enable it for the project.
 
-## 5. Create the Chrome extension OAuth client
+## 5. Lock the extension ID
+
+1. Load the unpacked extension and open the background service worker console. It now prints `EXT_ID <value>` on startup.
+2. Copy the ID shown there (or from `chrome://extensions`).
+3. In the Chrome Web Store Developer Dashboard, open **Package → View public key** and copy the public key.
+4. Paste the key into [`manifest.json`](../manifest.json) under the top-level `"key"` field so the unpacked and packaged IDs stay in sync.
+
+> **Why this matters:** Google OAuth for Chrome extensions requires that the OAuth client **Item ID** matches the extension ID exactly. Setting the manifest `key` locks the ID across rebuilds.
+
+## 6. Create the Chrome extension OAuth client
 
 1. Open **APIs & Services → Credentials** and click **Create credentials → OAuth client ID**.
 2. Choose **Chrome App** as the application type.
 3. When prompted for the application ID, supply the extension ID shown in `chrome://extensions` after loading KanbanX in developer mode.
 4. Click **Create** to generate the client. Copy the **Client ID** that is displayed.
 
-## 6. Update `manifest.json`
+## 7. Update `manifest.json`
 
 1. Open the project locally and edit [`manifest.json`](../manifest.json).
 2. Replace `YOUR_GOOGLE_CLIENT_ID.apps.googleusercontent.com` with the client ID you just copied.
-3. Save the file and reload the extension from `chrome://extensions`.
+3. Confirm that the `oauth2.scopes` array contains `https://www.googleapis.com/auth/drive.appdata`.
+4. Save the file and reload the extension from `chrome://extensions`.
 
 If you're preparing a build for distribution, double-check that the committed manifest contains the correct client ID. Never commit secrets such as client secrets—only the public client ID belongs in source control.
 
-## 7. Verify the integration
+## 8. Verify the integration
 
 1. Reload the side panel and click **Connect to G-Drive**.
 2. Chrome should open an OAuth prompt for the selected standard Google user.
-3. After authorising, the button should show **G-Drive Connected** and the notice should confirm the connection.
+3. The console logs a non-empty auth token (`KanbanX: Drive token acquired ...`) followed by the result of listing the AppData files (`KanbanX: AppData files ...`).
+4. After authorising, the button should show **G-Drive Connected** and the notice should confirm the connection.
 
-## 8. Rotating or replacing credentials
+## 9. Rotating or replacing credentials
 
 If you regenerate the client ID, update `manifest.json`, notify the team, and re-upload the updated package wherever it is distributed. All testers will need to reload the extension to pick up the new ID.
 

--- a/manifest.json
+++ b/manifest.json
@@ -3,6 +3,7 @@
   "name": "KanbanX",
   "description": "Local-first Kanban board in a Chrome side panel. Pure HTML/CSS/JS.",
   "version": "0.1.0",
+  "key": "REPLACE_WITH_PUBLIC_KEY_FROM_CHROME_DASHBOARD",
   "action": {
     "default_title": "Open KanbanX board"
   },

--- a/sidepanel/app.js
+++ b/sidepanel/app.js
@@ -14,7 +14,7 @@ import { renderBoard } from './board.js';
 import { escapeHtml } from './templates.js';
 import { openCardDetails, syncCardDetails, closeCardDetails } from './details.js';
 import './keyboard.js';
-import { connectDrive, isDriveConnected } from './drive.js';
+import { connectDrive, isDriveConnected, listDriveAppDataFiles } from './drive.js';
 
 const elSearch = document.getElementById('search');
 const elAddColumn = document.getElementById('addColumn');
@@ -60,6 +60,7 @@ if (elConnectDrive) {
   elConnectDrive.addEventListener('click', async () => {
     await updateDriveButton({ connecting: true });
     try {
+      await listDriveAppDataFiles({ interactive: true });
       await connectDrive(state);
       await saveState(state);
       showNotice('Connected to Google Drive. Boards will sync automatically.', 'success');


### PR DESCRIPTION
## Summary
- add a shared Drive auth helper for MV3 and log the extension ID on startup
- trigger a Drive AppData smoke test from the connect button and harden token refresh handling
- document the key/ID workflow and add the manifest key placeholder needed to align OAuth with the extension ID

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e57f093fd083288e8eeca09c6a23c5