### PR TITLE
Remove placeholder Chrome key from manifest

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,6 @@
   "name": "KanbanX",
   "description": "Local-first Kanban board in a Chrome side panel. Pure HTML/CSS/JS.",
   "version": "0.1.0",
-  "key": "REPLACE_WITH_PUBLIC_KEY_FROM_CHROME_DASHBOARD",
   "action": {
     "default_title": "Open KanbanX board"
   },


### PR DESCRIPTION
## Summary
- remove the placeholder extension key from the manifest so Chrome can load the unpacked build without errors

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5815a2f7c8328a7702e3651eabbc1