### PR TITLE
Clarify shared Google OAuth client usage

### DIFF
--- a/auth/driveAuth.js
+++ b/auth/driveAuth.js
@@ -15,7 +15,7 @@ export function ensureDriveOAuthConfigured() {
   const clientId = getManifestClientId();
   if (!clientId || clientId === PLACEHOLDER_CLIENT_ID) {
     throw new Error(
-      'Google OAuth client ID missing. Replace the placeholder in manifest.json (see docs/google-drive-setup.md).'
+      'Google OAuth client ID missing. Replace the placeholder in manifest.json (see docs/google-drive-setup.md for why this ID is shared across users).'
     );
   }
 }

--- a/docs/google-drive-setup.md
+++ b/docs/google-drive-setup.md
@@ -49,6 +49,11 @@ Use one of the organisation's shared "Standard Google Users" so the client ID is
 3. Confirm that the `oauth2.scopes` array contains `https://www.googleapis.com/auth/drive.appdata`.
 4. Save the file and reload the extension from `chrome://extensions`.
 
+> **FAQ: Does this stop other users from signing in with their own Google Drive?** No. The OAuth client ID uniquely identifies the
+> extension as an application, not an end user. Any teammate you add to the consent screen's **Test users** list can authorise
+> the extension with their personal Google Drive account. If somebody outside that list needs access, just add them (or publish
+> the consent screen) and they will see the standard Google sign-in flow while the extension continues to use the same client ID.
+
 If you're preparing a build for distribution, double-check that the committed manifest contains the correct client ID. Never commit secrets such as client secrets—only the public client ID belongs in source control.
 
 ## 8. Verify the integration


### PR DESCRIPTION
## Summary
- clarify the Google Drive setup guide to explain that a single OAuth client ID still allows individual Google Drive sign-ins
- update the runtime check error message to point to the documentation about shared OAuth client IDs

## Testing
- not run (documentation change)


------
https://chatgpt.com/codex/tasks/task_e_68e5824c428883289632cf517b3c0044