### PR TITLE
Fix column header overlap on wider boards

### DIFF
--- a/sidepanel/app.js
+++ b/sidepanel/app.js
@@ -24,6 +24,17 @@ const elRenameBoard = document.getElementById('renameBoard');
 const elDeleteBoard = document.getElementById('deleteBoard');
 const elNotice = document.getElementById('notice');
 const elConnectDrive = document.getElementById('connectDrive');
+const elHeader = document.querySelector('header');
+
+const rootStyle = document.documentElement?.style ?? null;
+
+const updateLayoutMetrics = () => {
+  if (!rootStyle) return;
+  const headerHeight = elHeader?.offsetHeight ?? 0;
+  const noticeHeight = elNotice?.offsetHeight ?? 0;
+  const offset = headerHeight + noticeHeight;
+  rootStyle.setProperty('--app-header-offset', `${offset}px`);
+};
 
 const createId = () =>
   typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
@@ -35,8 +46,16 @@ if (!state) {
   state = await initDefault();
 }
 
+const resizeObserver = typeof ResizeObserver === 'function' ? new ResizeObserver(updateLayoutMetrics) : null;
+if (resizeObserver) {
+  if (elHeader) resizeObserver.observe(elHeader);
+  if (elNotice) resizeObserver.observe(elNotice);
+}
+window.addEventListener('resize', updateLayoutMetrics, { passive: true });
+
 render();
 updateDriveButton();
+updateLayoutMetrics();
 
 elSearch.addEventListener('input', (event) => {
   state = withState(state, (draft) => {
@@ -127,6 +146,7 @@ function render() {
   });
   renderBoardControls();
   syncCardDetails(state, { onState, notify: showNotice });
+  updateLayoutMetrics();
 }
 
 async function onState(updater) {
@@ -174,6 +194,7 @@ function showNotice(message, variant = 'info') {
   if (!message) {
     elNotice.textContent = '';
     elNotice.removeAttribute('data-variant');
+    updateLayoutMetrics();
     return;
   }
   elNotice.textContent = message;
@@ -182,8 +203,10 @@ function showNotice(message, variant = 'info') {
   } else {
     elNotice.removeAttribute('data-variant');
   }
+  updateLayoutMetrics();
   noticeTimer = setTimeout(() => {
     elNotice.textContent = '';
     elNotice.removeAttribute('data-variant');
+    updateLayoutMetrics();
   }, 4000);
 }

--- a/sidepanel/styles.css
+++ b/sidepanel/styles.css
@@ -1,5 +1,7 @@
 :root {
   color-scheme: dark;
+  --app-header-offset: 72px;
+  --board-vertical-padding: 1.5rem;
 }
 
 * {
@@ -130,7 +132,7 @@ header button:disabled {
   display: flex;
   flex-direction: column;
   min-height: 420px;
-  max-height: calc(100vh - 72px);
+  max-height: calc(100vh - var(--app-header-offset) - var(--board-vertical-padding));
 }
 
 .col-head {
@@ -140,7 +142,7 @@ header button:disabled {
   gap: 0.5rem;
   border-bottom: 1px solid #1b1f2a;
   position: sticky;
-  top: 56px;
+  top: var(--app-header-offset);
   background: #0c0e13;
   z-index: 5;
 }


### PR DESCRIPTION
## Summary
- adjust the column layout CSS to use a shared sticky offset variable so headers reserve space for cards
- measure the header and notice height at runtime and update the CSS offset to prevent cards from sliding under column headers

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e583a61a2c83288b2a46903701eb43