### PR TITLE
Fix sticky column header spacing and show add card buttons

### DIFF
--- a/sidepanel/app.js
+++ b/sidepanel/app.js
@@ -31,7 +31,8 @@ const rootStyle = document.documentElement?.style ?? null;
 const updateLayoutMetrics = () => {
   if (!rootStyle) return;
   const headerHeight = elHeader?.offsetHeight ?? 0;
-  const noticeHeight = elNotice?.offsetHeight ?? 0;
+  const noticeVisible = Boolean(elNotice?.textContent?.trim());
+  const noticeHeight = noticeVisible ? (elNotice?.offsetHeight ?? 0) : 0;
   const offset = headerHeight + noticeHeight;
   rootStyle.setProperty('--app-header-offset', `${offset}px`);
 };

--- a/sidepanel/board.js
+++ b/sidepanel/board.js
@@ -29,9 +29,7 @@ export function renderBoard(state, { onState, onOpenCard, announce }) {
   );
 
   root.innerHTML = sortedColumns
-    .map((column, index) =>
-      renderColumn(board, column, query, index, sortedColumns.length, index === 0)
-    )
+    .map((column, index) => renderColumn(board, column, query, index, sortedColumns.length))
     .join('');
 
   const getDropZone = (element) => {
@@ -272,7 +270,7 @@ export function renderBoard(state, { onState, onOpenCard, announce }) {
   });
 }
 
-function renderColumn(board, column, query, index, totalColumns, showAddButton) {
+function renderColumn(board, column, query, index, totalColumns) {
   const cards = Array.isArray(board.cards) ? board.cards : [];
   const visibleCards = cards
     .filter((card) => card.columnId === column.id && matchesQuery(card, query))
@@ -352,9 +350,7 @@ function renderColumn(board, column, query, index, totalColumns, showAddButton) 
       <div class="card-list" data-col-id="${column.id}" role="list">
         ${visibleCards.map((card) => cardView(card)).join('')}
       </div>
-      ${showAddButton
-        ? html`<button class="add-card" data-col-id="${column.id}">+ Add card</button>`
-        : ''}
+      <button class="add-card" data-col-id="${column.id}">+ Add card</button>
     </section>`;
 }
 


### PR DESCRIPTION
## Summary
- adjust the layout metrics so column headers stick directly under the visible header/notice
- render the "+ Add card" control for every column so tasks can be added anywhere

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e5bc6924c48328be1c755c65aa0769