### PR TITLE
Add first-position column creation and align column headers

### DIFF
--- a/sidepanel/app.js
+++ b/sidepanel/app.js
@@ -66,12 +66,11 @@ elSearch.addEventListener('input', (event) => {
 });
 
 elAddColumn.addEventListener('click', () => {
-  const board = getActiveBoard(state);
   const nextColumn = {
     id: createId(),
     name: 'New',
     wip: null,
-    order: board ? board.columns.length : 0
+    order: -1
   };
   onState((current) => addColumn(current, nextColumn));
 });

--- a/sidepanel/state.js
+++ b/sidepanel/state.js
@@ -105,7 +105,11 @@ export function addColumn(state, column) {
   return withState(state, (draft) => {
     const board = getActiveBoard(draft);
     if (!board) return;
-    board.columns.push({ ...column });
+    if (!Array.isArray(board.columns)) {
+      board.columns = [];
+    }
+    const nextColumn = { ...column, order: -1 };
+    board.columns.unshift(nextColumn);
     normalizeColumnOrder(board);
   });
 }

--- a/sidepanel/styles.css
+++ b/sidepanel/styles.css
@@ -138,13 +138,20 @@ header button:disabled {
 .col-head {
   padding: 0.55rem 0.6rem;
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   gap: 0.5rem;
   border-bottom: 1px solid #1b1f2a;
   position: sticky;
   top: var(--app-header-offset);
   background: #0c0e13;
   z-index: 5;
+}
+
+.col-actions {
+  display: flex;
+  gap: 0.25rem;
+  flex-shrink: 0;
+  align-items: flex-start;
 }
 
 .col-title {
@@ -155,12 +162,6 @@ header button:disabled {
 .wip {
   opacity: 0.6;
   font-size: 0.82em;
-  flex-shrink: 0;
-}
-
-.col-actions {
-  display: flex;
-  gap: 0.25rem;
   flex-shrink: 0;
 }
 


### PR DESCRIPTION
## Summary
- ensure newly created columns are inserted at the front of the board regardless of existing order
- align column headers and action buttons to the top edge for consistent appearance

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e5c1a58b0083288e8cc6344753b07b