### PR TITLE
Limit add-card button and refine column header spacing

### DIFF
--- a/sidepanel/board.js
+++ b/sidepanel/board.js
@@ -292,6 +292,11 @@ function renderColumn(board, column, query, index, totalColumns) {
   const disableLeft = index === 0 ? 'disabled' : '';
   const disableRight = index === totalColumns - 1 ? 'disabled' : '';
 
+  const showAddCardButton = index === 0;
+  const addCardButton = showAddCardButton
+    ? html`<button class="add-card" data-col-id="${column.id}">+ Add card</button>`
+    : '';
+
   return html`<section
       class="column"
       data-col-id="${column.id}"
@@ -350,7 +355,7 @@ function renderColumn(board, column, query, index, totalColumns) {
       <div class="card-list" data-col-id="${column.id}" role="list">
         ${visibleCards.map((card) => cardView(card)).join('')}
       </div>
-      <button class="add-card" data-col-id="${column.id}">+ Add card</button>
+      ${addCardButton}
     </section>`;
 }
 

--- a/sidepanel/styles.css
+++ b/sidepanel/styles.css
@@ -136,14 +136,16 @@ header button:disabled {
 }
 
 .col-head {
-  padding: 0.55rem 0.6rem;
+  padding: 0.35rem 0.6rem 0.55rem;
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   gap: 0.5rem;
   border-bottom: 1px solid #1b1f2a;
   position: sticky;
   top: var(--app-header-offset);
   background: #0c0e13;
+  border-top-left-radius: 0.6rem;
+  border-top-right-radius: 0.6rem;
   z-index: 5;
 }
 


### PR DESCRIPTION
## Summary
- render the "+ Add card" action only for the first column so duplicate buttons are removed
- tighten the column header padding and give it top corner radii to visually connect it to the column body

## Testing
- Manual: Loaded the sidepanel in a stubbed browser session to confirm only the first column shows the add card button and the header sits flush with the column

------
https://chatgpt.com/codex/tasks/task_e_68e65a7ba3108328a366769f1534cbdd