### PR TITLE
Move column headers above column content

### DIFF
--- a/sidepanel/board.js
+++ b/sidepanel/board.js
@@ -38,8 +38,15 @@ export function renderBoard(state, { onState, onOpenCard, announce }) {
       return element;
     }
     const column = element.closest('.column');
-    if (!column) return null;
-    const list = column.querySelector('.card-list');
+    if (column) {
+      const list = column.querySelector('.card-list');
+      if (list instanceof HTMLElement) {
+        return list;
+      }
+    }
+    const wrapper = element.closest('.column-wrapper');
+    if (!wrapper) return null;
+    const list = wrapper.querySelector('.column .card-list');
     return list instanceof HTMLElement ? list : null;
   };
 
@@ -108,6 +115,10 @@ export function renderBoard(state, { onState, onOpenCard, announce }) {
       if (column?.contains(nextTarget)) {
         return;
       }
+      const wrapper = zone.closest('.column-wrapper');
+      if (wrapper?.contains(nextTarget)) {
+        return;
+      }
     }
     zone.classList.remove('drag-over');
   };
@@ -124,6 +135,13 @@ export function renderBoard(state, { onState, onOpenCard, announce }) {
     columnEl.addEventListener('dragover', allowDrop);
     columnEl.addEventListener('dragleave', handleDragLeave);
     columnEl.addEventListener('drop', handleDrop);
+  });
+
+  root.querySelectorAll('.column-wrapper').forEach((wrapper) => {
+    wrapper.addEventListener('dragenter', allowDrop);
+    wrapper.addEventListener('dragover', allowDrop);
+    wrapper.addEventListener('dragleave', handleDragLeave);
+    wrapper.addEventListener('drop', handleDrop);
   });
 
   root.querySelectorAll('.card').forEach((cardEl) => {
@@ -297,12 +315,7 @@ function renderColumn(board, column, query, index, totalColumns) {
     ? html`<button class="add-card" data-col-id="${column.id}">+ Add card</button>`
     : '';
 
-  return html`<section
-      class="column"
-      data-col-id="${column.id}"
-      role="region"
-      aria-labelledby="col-${column.id}"
-    >
+  return html`<article class="column-wrapper">
       <div class="col-head">
         <div class="col-title" id="col-${column.id}">${column.name}</div>
         <div class="wip" aria-hidden="true">${wipText}</div>
@@ -352,11 +365,18 @@ function renderColumn(board, column, query, index, totalColumns) {
         </div>
         <span class="sr-only">${wipAccessible}</span>
       </div>
-      <div class="card-list" data-col-id="${column.id}" role="list">
-        ${visibleCards.map((card) => cardView(card)).join('')}
-      </div>
-      ${addCardButton}
-    </section>`;
+      <section
+        class="column"
+        data-col-id="${column.id}"
+        role="region"
+        aria-labelledby="col-${column.id}"
+      >
+        <div class="card-list" data-col-id="${column.id}" role="list">
+          ${visibleCards.map((card) => cardView(card)).join('')}
+        </div>
+        ${addCardButton}
+      </section>
+    </article>`;
 }
 
 function matchesQuery(card, query) {

--- a/sidepanel/styles.css
+++ b/sidepanel/styles.css
@@ -125,14 +125,24 @@ header button:disabled {
   overflow: auto;
 }
 
+.column-wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  min-height: 420px;
+  max-height: calc(100vh - var(--app-header-offset) - var(--board-vertical-padding));
+}
+
 .column {
   background: #0c0e13;
   border: 1px solid #1b1f2a;
-  border-radius: 0.6rem;
+  border-top: none;
+  border-bottom-left-radius: 0.6rem;
+  border-bottom-right-radius: 0.6rem;
   display: flex;
   flex-direction: column;
-  min-height: 420px;
-  max-height: calc(100vh - var(--app-header-offset) - var(--board-vertical-padding));
+  flex: 1;
+  min-height: 0;
 }
 
 .col-head {
@@ -140,6 +150,7 @@ header button:disabled {
   display: flex;
   align-items: center;
   gap: 0.5rem;
+  border: 1px solid #1b1f2a;
   border-bottom: 1px solid #1b1f2a;
   position: sticky;
   top: var(--app-header-offset);
@@ -195,6 +206,8 @@ header button:disabled {
   flex-direction: column;
   gap: 0.5rem;
   padding: 0.6rem;
+  flex: 1 1 auto;
+  min-height: 0;
   overflow: auto;
 }
 


### PR DESCRIPTION
## Summary
- render column headers outside the column section so titles sit above the card list while keeping aria labelling intact
- update drag-and-drop helpers to resolve the card list from the new wrapper and allow drops anywhere on the column stack
- restyle the column container and card list to split header/body borders and maintain scrolling

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e6627697d88328a213973fac776d7e