### PR TITLE
Align column headers with board top

### DIFF
--- a/sidepanel/styles.css
+++ b/sidepanel/styles.css
@@ -1,7 +1,7 @@
 :root {
   color-scheme: dark;
   --app-header-offset: 72px;
-  --board-vertical-padding: 1.5rem;
+  --board-vertical-padding: 0.75rem;
 }
 
 * {
@@ -121,7 +121,7 @@ header button:disabled {
   grid-auto-flow: column;
   grid-auto-columns: 280px;
   gap: 0.75rem;
-  padding: 0.75rem;
+  padding: 0 0.75rem 0.75rem;
   overflow: auto;
 }
 


### PR DESCRIPTION
## Summary
- remove the extra top padding from the board grid so column headers sit flush with the top edge
- adjust the board vertical padding variable to match the new spacing and preserve column heights

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e66d6ab01083289f5ed9a1e81eb5c7