### PR TITLE
Reduce column header gap to 1rem

### DIFF
--- a/sidepanel/board.js
+++ b/sidepanel/board.js
@@ -340,53 +340,55 @@ function renderColumn(board, column, query, index, totalColumns) {
         aria-labelledby="col-${column.id}"
       >
         <div class="col-head">
-          <div class="col-title" id="col-${column.id}">${column.name}</div>
-          <div class="wip" aria-hidden="true">${wipText}</div>
-          <div class="col-actions" role="group" aria-label="Column actions">
-            <button
-              class="icon-button col-move-left"
-              data-col-id="${column.id}"
-              ${disableLeft}
-              title="Move column left"
-              aria-label="Move column left"
-            >
-              <span aria-hidden="true">◀</span>
-            </button>
-            <button
-              class="icon-button col-move-right"
-              data-col-id="${column.id}"
-              ${disableRight}
-              title="Move column right"
-              aria-label="Move column right"
-            >
-              <span aria-hidden="true">▶</span>
-            </button>
-            <button
-              class="icon-button col-rename"
-              data-col-id="${column.id}"
-              title="Rename column"
-              aria-label="Rename column"
-            >
-              <span aria-hidden="true">✏️</span>
-            </button>
-            <button
-              class="icon-button col-limit"
-              data-col-id="${column.id}"
-              title="Set max cards"
-              aria-label="Set max cards"
-            >
-              <span aria-hidden="true">#</span>
-            </button>
-            <button
-              class="icon-button col-delete"
-              data-col-id="${column.id}"
-              title="Delete column"
-              aria-label="Delete column"
-            >
-              <span aria-hidden="true">🗑️</span>
-            </button>
+          <div class="col-head-inner">
+            <div class="col-title" id="col-${column.id}">${column.name}</div>
+            <div class="wip" aria-hidden="true">${wipText}</div>
+            <div class="col-actions" role="group" aria-label="Column actions">
+              <button
+                class="icon-button col-move-left"
+                data-col-id="${column.id}"
+                ${disableLeft}
+                title="Move column left"
+                aria-label="Move column left"
+              >
+                <span aria-hidden="true">◀</span>
+              </button>
+              <button
+                class="icon-button col-move-right"
+                data-col-id="${column.id}"
+                ${disableRight}
+                title="Move column right"
+                aria-label="Move column right"
+              >
+                <span aria-hidden="true">▶</span>
+              </button>
+              <button
+                class="icon-button col-rename"
+                data-col-id="${column.id}"
+                title="Rename column"
+                aria-label="Rename column"
+              >
+                <span aria-hidden="true">✏️</span>
+              </button>
+              <button
+                class="icon-button col-limit"
+                data-col-id="${column.id}"
+                title="Set max cards"
+                aria-label="Set max cards"
+              >
+                <span aria-hidden="true">#</span>
+              </button>
+              <button
+                class="icon-button col-delete"
+                data-col-id="${column.id}"
+                title="Delete column"
+                aria-label="Delete column"
+              >
+                <span aria-hidden="true">🗑️</span>
+              </button>
+            </div>
+            <span class="sr-only">${wipAccessible}</span>
           </div>
-          <span class="sr-only">${wipAccessible}</span>
         </div>
         <div class="card-list" data-col-id="${column.id}" role="list">
           ${visibleCards.map((card) => cardView(card)).join('')}

--- a/sidepanel/styles.css
+++ b/sidepanel/styles.css
@@ -146,18 +146,23 @@ header button:disabled {
 }
 
 .col-head {
-  padding: 0.35rem 0.6rem 0.55rem;
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  border: 1px solid #1b1f2a;
-  border-bottom: 1px solid #1b1f2a;
   position: sticky;
   top: var(--app-header-offset);
   background: #0c0e13;
+  border: 1px solid #1b1f2a;
+  border-bottom: 1px solid #1b1f2a;
   border-top-left-radius: 0.6rem;
   border-top-right-radius: 0.6rem;
   z-index: 5;
+  padding: 0;
+}
+
+.col-head-inner {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.35rem 0.6rem 0.55rem;
+  margin-top: min(0rem, calc(1rem - var(--app-header-offset)));
 }
 
 .col-actions {


### PR DESCRIPTION
## Summary
- wrap each column header in a `.col-head-inner` container so the controls can be shifted upward
- adjust the column header CSS to pull the inner content up, limiting the visible gap to 1rem while keeping the sticky behavior

## Testing
- Manual visual inspection of the sidepanel layout

------
https://chatgpt.com/codex/tasks/task_e_68e67428c4b88328a2403b3815187aa0