### PR TITLE
Fix sticky column headers covering top cards

### DIFF
--- a/sidepanel/styles.css
+++ b/sidepanel/styles.css
@@ -212,7 +212,8 @@ header button:disabled {
   flex-direction: column;
   gap: 0.5rem;
   padding: 0 0.6rem 0.6rem;
-  padding-top: calc(0.6rem + var(--column-head-height));
+  padding-top: calc(0.6rem + var(--column-head-height, 0px));
+  scroll-padding-top: calc(0.6rem + var(--column-head-height, 0px));
   margin-top: 0;
   flex: 1 1 auto;
   min-height: 0;


### PR DESCRIPTION
## Summary
- keep column header height offsets in sync with a ResizeObserver so cards start below the heading
- add CSS fallbacks for the column head offset to prevent overlap and improve scrolling behavior

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68e678b7b0888328911074c8cb330b19