### PR TITLE
Move column headers outside columns

### DIFF
--- a/sidepanel/styles.css
+++ b/sidepanel/styles.css
@@ -207,13 +207,11 @@ header button:disabled {
 }
 
 .card-list {
-  --column-head-height: 0px;
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
-  padding: 0 0.6rem 0.6rem;
-  padding-top: calc(0.6rem + var(--column-head-height, 0px));
-  scroll-padding-top: calc(0.6rem + var(--column-head-height, 0px));
+  padding: 0.6rem;
+  scroll-padding-top: 0.6rem;
   margin-top: 0;
   flex: 1 1 auto;
   min-height: 0;


### PR DESCRIPTION
## Summary
- render each column header outside of the column container so the heading sits above the cards
- simplify card list padding now that headers are external, removing the JavaScript resize observer

## Testing
- not run (extension UI change)


------
https://chatgpt.com/codex/tasks/task_e_68e67a6868688328b7e50c9bd61ed97d