### PR TITLE
Adjust column list padding

### DIFF
--- a/sidepanel/styles.css
+++ b/sidepanel/styles.css
@@ -210,8 +210,8 @@ header button:disabled {
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
-  padding: 0.6rem;
-  scroll-padding-top: 0.6rem;
+  padding: 1rem 0.6rem 0.6rem;
+  scroll-padding-top: 1rem;
   margin-top: 0;
   flex: 1 1 auto;
   min-height: 0;


### PR DESCRIPTION
## Summary
- increase the top padding for column card lists so the first card no longer sits beneath the column heading
- align the scroll padding with the new spacing to preserve anchor alignment

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e67e1952c08328b430c67fdb7329de