### PR TITLE
Adjust column spacing in side panel

### DIFF
--- a/sidepanel/styles.css
+++ b/sidepanel/styles.css
@@ -1,7 +1,7 @@
 :root {
   color-scheme: dark;
   --app-header-offset: 72px;
-  --board-vertical-padding: 0.75rem;
+  --board-vertical-padding: 1.25rem;
 }
 
 * {
@@ -121,7 +121,7 @@ header button:disabled {
   grid-auto-flow: column;
   grid-auto-columns: 280px;
   gap: 0.75rem;
-  padding: 0 0.75rem 0.75rem;
+  padding: var(--board-vertical-padding) 0.75rem 0.75rem;
   overflow: auto;
 }
 
@@ -212,8 +212,8 @@ header button:disabled {
   flex-direction: column;
   gap: 0.5rem;
   padding: 0 0.6rem 0.6rem;
-  padding-top: calc(1rem + var(--first-card-offset, 0px));
-  scroll-padding-top: calc(1rem + var(--first-card-offset, 0px));
+  padding-top: calc(1.5rem + var(--first-card-offset, 0px));
+  scroll-padding-top: calc(1.5rem + var(--first-card-offset, 0px));
   margin-top: 0;
   flex: 1 1 auto;
   min-height: 0;


### PR DESCRIPTION
## Summary
- increase the side panel board's top padding so columns sit lower below the header
- add extra spacing between each column header and its list of cards for clearer separation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e684e8b4208328b751c1a5f87732fd